### PR TITLE
fix Création/édition de page

### DIFF
--- a/src/Synapse/Page/Bundle/Resources/views/Admin/Page/edit.html.twig
+++ b/src/Synapse/Page/Bundle/Resources/views/Admin/Page/edit.html.twig
@@ -82,7 +82,7 @@
           {{ form_widget(form.synapse) }}
         {% else %}
           <div class="panel-body">
-            You have not active theme. Create one of them to apply template to this content.
+            WARNING: You have not active theme. You will not be able to display the page. Create one of them to apply a template to this content.
           </div>
         {% endif %}
       </div>

--- a/src/Synapse/Page/Bundle/Resources/views/Admin/Page/edit.html.twig
+++ b/src/Synapse/Page/Bundle/Resources/views/Admin/Page/edit.html.twig
@@ -78,7 +78,13 @@
           </a>
           <h3>Content</h3>
         </header>
-        {{ form_widget(form.synapse) }}
+        {% if form.synapse is defined %}
+          {{ form_widget(form.synapse) }}
+        {% else %}
+          <div class="panel-body">
+            You have not active theme. Create one of them to apply template to this content.
+          </div>
+        {% endif %}
       </div>
 
       {# Tech #}


### PR DESCRIPTION
Permet à l'utilisateur de pouvoir créer des pages sans thème enregistré. Sinon, la page d'édition ou de création lançait une 500.
