### PR TITLE
Give reduce initial value

### DIFF
--- a/src/Synapse/Cmf/Framework/Engine/Renderer/Zone/ZoneRenderer.php
+++ b/src/Synapse/Cmf/Framework/Engine/Renderer/Zone/ZoneRenderer.php
@@ -117,7 +117,7 @@ class ZoneRenderer
                     })
                     ->toArray()
                 ;
-            }),
+            }, []),
             $aggregationConfig
         );
     }


### PR DESCRIPTION
If you don't give reduce an initial value, it breaks the type checker array of the method aggregates.
This way, it also allows empty zones in a template. If you don't want to allow this behavior, the aggregate method must accept null, or we must check the value before calling it (and throw a comprehensible extension)